### PR TITLE
Use .getActiveVault().vaultKey instead of stored password

### DIFF
--- a/js/app/controllers/edit_credential.js
+++ b/js/app/controllers/edit_credential.js
@@ -28,7 +28,7 @@
 				}
 
 				VaultService.getVault($scope.active_vault).then(function (vault) {
-					vault.vaultKey = SettingsService.getSetting('defaultVaultPass');
+					vault.vaultKey = VaultService.getActiveVault().vaultKey;
 					delete vault.credentials;
 					VaultService.setActiveVault(vault);
 					$scope.pwSettings = VaultService.getVaultSetting('pwSettings',


### PR DESCRIPTION
If the user decides not to store password, the stored password is empty, resulting in various encryption / decryption errors.