### PR TITLE
Removed required instance of IUser

### DIFF
--- a/controller/sharecontroller.php
+++ b/controller/sharecontroller.php
@@ -55,7 +55,7 @@ class ShareController extends ApiController {
 
 	public function __construct($AppName,
 								IRequest $request,
-								IUser $UserId,
+								$UserId,
 								IGroupManager $groupManager,
 								IUserManager $userManager,
 								ActivityService $activityService,


### PR DESCRIPTION
This because when using link sharing $UserId is not an instance
of IUser.