### PR TITLE
Implement Server side encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Untested databases:
 
 For more screenshots: [Click here](http://imgur.com/a/giKVt)
 
+## Encryption (server side)
+All passwords are encrypted client side AND server side.
+This means that if you move to another server you have to backup the following from config.php
+- `passwordsalt`
+- `secret`
+
+
+
+
 ## Code reviews
 If you have any improvements regarding our code.
 Please do the following

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ For an demo of this app visit [https://demo.passman.cc](https://demo.passman.cc)
 ]]></description>
 
     <licence>AGPL</licence>
-    <version>2.0.0-RC3</version>
+    <version>2.0.0-RC4</version>
     <author homepage="https://github.com/brantje">Sander Brand</author>
     <author homepage="https://github.com/animalillo">Marcos Zuriaga</author>
     <namespace>Passman</namespace>
@@ -39,7 +39,14 @@ For an demo of this app visit [https://demo.passman.cc](https://demo.passman.cc)
         <nextcloud min-version="9" max-version="12" />
         <database>sqlite</database>
         <database min-version="5.5">mysql</database>
+        <lib>openssl</lib>
     </dependencies>
+
+    <repair-steps>
+        <post-migration>
+            <step>OCA\Passman\Migration\ServerSideEncryption</step>
+        </post-migration>
+    </repair-steps>
 
     <settings>
         <admin>OCA\Passman\Controller\SettingsController</admin>

--- a/controller/credentialcontroller.php
+++ b/controller/credentialcontroller.php
@@ -240,6 +240,11 @@ class CredentialController extends ApiController {
 			$storedCredential->setSharedKey('');
 			$credential['shared_key'] = '';
 		}
+
+		if(!isset($credential['shared_key'])){
+			$credential['shared_key'] = $storedCredential->getSharedKey();
+		}
+
 		if (!$skip_revision) {
 			$this->credentialRevisionService->createRevision($storedCredential, $storedCredential->getUserId(), $credential_id, $this->userId);
 		}

--- a/controller/filecontroller.php
+++ b/controller/filecontroller.php
@@ -39,7 +39,8 @@ class FileController extends ApiController {
 			'filename' => $filename,
 			'size' => $size,
 			'mimetype' => $mimetype,
-			'file_data' => $data
+			'file_data' => $data,
+			'user_id' => $this->userId
 		);
 		return new JSONResponse($this->fileService->createFile($file, $this->userId));
 	}

--- a/controller/sharecontroller.php
+++ b/controller/sharecontroller.php
@@ -464,12 +464,12 @@ class ShareController extends ApiController {
 	}
 
 	/**
-	 * @param $credential_guid
+	 * @param $item_guid
 	 * @param $file_guid
 	 * @NoAdminRequired
 	 * @PublicPage
-	 * @return JSONResponse
-	 * @return NotFoundResponse
+	 * @return mixed
+	 * @return NotFoundJSONResponse
 	 */
 	public function getFile($item_guid, $file_guid) {
 		try {

--- a/controller/vaultcontroller.php
+++ b/controller/vaultcontroller.php
@@ -11,6 +11,8 @@
 
 namespace OCA\Passman\Controller;
 
+use OCA\Passman\Service\EncryptService;
+use OCA\Passman\Service\SettingsService;
 use OCA\Passman\Utility\NotFoundJSONResponse;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IRequest;
@@ -24,12 +26,15 @@ class VaultController extends ApiController {
 	private $userId;
 	private $vaultService;
 	private $credentialService;
+	private $settings;
 
 	public function __construct($AppName,
 								IRequest $request,
 								$UserId,
 								VaultService $vaultService,
-								CredentialService $credentialService) {
+								CredentialService $credentialService,
+								SettingsService $settings,
+								EncryptService $encryptService) {
 		parent::__construct(
 			$AppName,
 			$request,
@@ -39,6 +44,7 @@ class VaultController extends ApiController {
 		$this->userId = $UserId;
 		$this->vaultService = $vaultService;
 		$this->credentialService = $credentialService;
+		$this->settings = $settings;
 	}
 
 	/**
@@ -61,7 +67,7 @@ class VaultController extends ApiController {
 					'created' => $vault->getCreated(),
 					'public_sharing_key' => $vault->getPublicSharingKey(),
 					'last_access' => $vault->getlastAccess(),
-					'challenge_password' => $credential->{$secret_field}()
+					'challenge_password' => $credential->{$secret_field}(),
 				));
 			}
 		}
@@ -83,7 +89,6 @@ class VaultController extends ApiController {
 	 * @NoCSRFRequired
 	 */
 	public function get($vault_guid) {
-		//$vault_guid
 		$vault = null;
 		try {
 			$vault = $this->vaultService->getByGuid($vault_guid, $this->userId);

--- a/controller/vaultcontroller.php
+++ b/controller/vaultcontroller.php
@@ -33,8 +33,7 @@ class VaultController extends ApiController {
 								$UserId,
 								VaultService $vaultService,
 								CredentialService $credentialService,
-								SettingsService $settings,
-								EncryptService $encryptService) {
+								SettingsService $settings) {
 		parent::__construct(
 			$AppName,
 			$request,

--- a/lib/Db/CredentialMapper.php
+++ b/lib/Db/CredentialMapper.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Db\Mapper;
 
 class CredentialMapper extends Mapper {
 	private $utils;
+
 	public function __construct(IDBConnection $db, Utils $utils) {
 		parent::__construct($db, 'passman_credentials');
 		$this->utils = $utils;
@@ -37,6 +38,7 @@ class CredentialMapper extends Mapper {
 
 	/**
 	 * Obtains the credentials by vault id (not guid)
+	 *
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more than one result
 	 * @return Credential[]
@@ -49,6 +51,7 @@ class CredentialMapper extends Mapper {
 
 	/**
 	 * Get a random credentail from a vault
+	 *
 	 * @param $vault_id
 	 * @param $user_id
 	 * @return Credential
@@ -57,58 +60,62 @@ class CredentialMapper extends Mapper {
 		$sql = 'SELECT * FROM `*PREFIX*passman_credentials` ' .
 			'WHERE `user_id` = ? and vault_id = ? AND shared_key is NULL LIMIT 20';
 		$entities = $this->findEntities($sql, [$user_id, $vault_id]);
-		$count = count($entities)-1;
+		$count = count($entities) - 1;
 		$entities = array_splice($entities, rand(0, $count), 1);
 		return $entities;
 	}
 
 	/**
 	 * Get expired credentials
+	 *
 	 * @param $timestamp
 	 * @return Credential[]
 	 */
-	public function getExpiredCredentials($timestamp){
+	public function getExpiredCredentials($timestamp) {
 		$sql = 'SELECT * FROM `*PREFIX*passman_credentials` ' .
 			'WHERE `expire_time` > 0 AND `expire_time` < ?';
 		return $this->findEntities($sql, [$timestamp]);
 	}
 
-    /**
+	/**
 	 * Get an credential by id.
 	 * Optional user id
-     * @param $credential_id
-     * @param null $user_id
-     * @return Credential
-     */
-	public function getCredentialById($credential_id, $user_id = null){
+	 *
+	 * @param $credential_id
+	 * @param null $user_id
+	 * @return Credential
+	 */
+	public function getCredentialById($credential_id, $user_id = null) {
 		$sql = 'SELECT * FROM `*PREFIX*passman_credentials` ' .
 			'WHERE `id` = ?';
-        // If we want to check the owner, add it to the query
+		// If we want to check the owner, add it to the query
 		$params = [$credential_id];
-        if ($user_id !== null){
-        	$sql .= ' and `user_id` = ? ';
+		if ($user_id !== null) {
+			$sql .= ' and `user_id` = ? ';
 			array_push($params, $user_id);
 		}
-		return $this->findEntity($sql,$params);
+		return $this->findEntity($sql, $params);
 	}
 
 	/**
 	 * Get credential label by id
+	 *
 	 * @param $credential_id
 	 * @return Credential
 	 */
-	public function getCredentialLabelById($credential_id){
+	public function getCredentialLabelById($credential_id) {
 		$sql = 'SELECT id, label FROM `*PREFIX*passman_credentials` ' .
 			'WHERE `id` = ? ';
-		return $this->findEntity($sql,[$credential_id]);
+		return $this->findEntity($sql, [$credential_id]);
 	}
 
 	/**
 	 * Save credential to the database.
+	 *
 	 * @param $raw_credential
 	 * @return Credential
 	 */
-	public function create($raw_credential){
+	public function create($raw_credential) {
 		$credential = new Credential();
 
 		$credential->setGuid($this->utils->GUID());
@@ -131,7 +138,7 @@ class CredentialMapper extends Mapper {
 		$credential->setCustomFields($raw_credential['custom_fields']);
 		$credential->setOtp($raw_credential['otp']);
 		$credential->setHidden($raw_credential['hidden']);
-		if(isset($raw_credential['shared_key'])) {
+		if (isset($raw_credential['shared_key'])) {
 			$credential->setSharedKey($raw_credential['shared_key']);
 		}
 		return parent::insert($credential);
@@ -139,10 +146,11 @@ class CredentialMapper extends Mapper {
 
 	/**
 	 * Update a credential
+	 *
 	 * @param $raw_credential array An array containing all the credential fields
 	 * @return Credential The updated credential
 	 */
-	public function updateCredential($raw_credential){
+	public function updateCredential($raw_credential) {
 		$original = $this->getCredentialByGUID($raw_credential['guid']);
 		$credential = new Credential();
 		$credential->setId($original->getId());
@@ -166,32 +174,33 @@ class CredentialMapper extends Mapper {
 		$credential->setOtp($raw_credential['otp']);
 		$credential->setHidden($raw_credential['hidden']);
 		$credential->setDeleteTime($raw_credential['delete_time']);
-		if(isset($raw_credential['shared_key'])) {
+		if (isset($raw_credential['shared_key'])) {
 			$credential->setSharedKey($raw_credential['shared_key']);
 		}
 		return parent::update($credential);
 	}
 
-	public function deleteCredential(Credential $credential){
+	public function deleteCredential(Credential $credential) {
 		return $this->delete($credential);
 	}
 
-	public function upd(Credential $credential){
+	public function upd(Credential $credential) {
 		$this->update($credential);
 	}
 
-    /**
-     * Finds a credential by the given guid
-     * @param $credential_guid
-     * @return Credential
-     */
-	public function getCredentialByGUID($credential_guid, $user_id = null){
-	    $q = 'SELECT * FROM `*PREFIX*passman_credentials` WHERE guid = ? ';
+	/**
+	 * Finds a credential by the given guid
+	 *
+	 * @param $credential_guid
+	 * @return Credential
+	 */
+	public function getCredentialByGUID($credential_guid, $user_id = null) {
+		$q = 'SELECT * FROM `*PREFIX*passman_credentials` WHERE guid = ? ';
 		$params = [$credential_guid];
-		if ($user_id !== null){
+		if ($user_id !== null) {
 			$q .= ' and `user_id` = ? ';
 			array_push($params, $user_id);
 		}
-        return $this->findEntity($q, $params);
-    }
+		return $this->findEntity($q, $params);
+	}
 }

--- a/lib/Db/CredentialMapper.php
+++ b/lib/Db/CredentialMapper.php
@@ -39,7 +39,7 @@ class CredentialMapper extends Mapper {
 	 * Obtains the credentials by vault id (not guid)
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more than one result
-	 * @return Vault[]
+	 * @return Credential[]
 	 */
 	public function getCredentialsByVaultId($vault_id, $user_id) {
 		$sql = 'SELECT * FROM `*PREFIX*passman_credentials` ' .
@@ -166,7 +166,9 @@ class CredentialMapper extends Mapper {
 		$credential->setOtp($raw_credential['otp']);
 		$credential->setHidden($raw_credential['hidden']);
 		$credential->setDeleteTime($raw_credential['delete_time']);
-		$credential->setSharedKey($raw_credential['shared_key']);
+		if(isset($raw_credential['shared_key'])) {
+			$credential->setSharedKey($raw_credential['shared_key']);
+		}
 		return parent::update($credential);
 	}
 

--- a/lib/Db/CredentialRevision.php
+++ b/lib/Db/CredentialRevision.php
@@ -49,7 +49,7 @@ class CredentialRevision extends Entity implements \JsonSerializable {
 	protected $credentialId;
 	protected $userId;
 	protected $created;
-	protected $credentialData;
+	public $credentialData;
     protected $editedBy;
 
 

--- a/lib/Db/CredentialRevision.php
+++ b/lib/Db/CredentialRevision.php
@@ -49,7 +49,7 @@ class CredentialRevision extends Entity implements \JsonSerializable {
 	protected $credentialId;
 	protected $userId;
 	protected $created;
-	public $credentialData;
+	protected $credentialData;
     protected $editedBy;
 
 

--- a/lib/Service/CredentialRevisionService.php
+++ b/lib/Service/CredentialRevisionService.php
@@ -44,6 +44,7 @@ class CredentialRevisionService {
 
 	/**
 	 * Create a new revision for a credential
+	 *
 	 * @param $credential
 	 * @param $userId
 	 * @param $credential_id
@@ -57,13 +58,14 @@ class CredentialRevisionService {
 
 	/**
 	 * Get revisions of a credential
+	 *
 	 * @param $credential_id
 	 * @param null $user_id
 	 * @return CredentialRevision[]
 	 */
-	public function getRevisions($credential_id, $user_id = null){
+	public function getRevisions($credential_id, $user_id = null) {
 		$result = $this->credentialRevisionMapper->getRevisions($credential_id, $user_id);
-		foreach ($result as $index => $revision){
+		foreach ($result as $index => $revision) {
 			$c = json_decode(base64_decode($revision->getCredentialData()), true);
 			$result[$index] = $revision->jsonSerialize();
 			$result[$index]['credential_data'] = $this->encryptService->decryptCredential($c);
@@ -77,7 +79,7 @@ class CredentialRevisionService {
 	 * @param null $user_id
 	 * @return CredentialRevision
 	 */
-	public function getRevision($credential_id, $user_id = null){
+	public function getRevision($credential_id, $user_id = null) {
 		$revision = $this->credentialRevisionMapper->getRevision($credential_id, $user_id);
 		$c = json_decode(base64_decode($revision->getCredentialData()), true);
 		$revision->setCredentialData($this->encryptService->decryptCredential($c));
@@ -86,20 +88,22 @@ class CredentialRevisionService {
 
 	/**
 	 * Delete a revision
+	 *
 	 * @param $revision_id
 	 * @param $user_id
 	 * @return CredentialRevision
 	 */
-	public function deleteRevision($revision_id, $user_id){
+	public function deleteRevision($revision_id, $user_id) {
 		return $this->credentialRevisionMapper->deleteRevision($revision_id, $user_id);
 	}
 
 	/**
 	 * Update revision
+	 *
 	 * @param CredentialRevision $credentialRevision
 	 * @return CredentialRevision
 	 */
-	public function updateRevision(CredentialRevision $credentialRevision){
+	public function updateRevision(CredentialRevision $credentialRevision) {
 		$credential_data = $credentialRevision->getCredentialData();
 		$credential_data = json_decode(base64_decode($credential_data), true);
 		$credential_data = base64_encode(json_encode($this->encryptService->encryptCredential($credential_data)));

--- a/lib/Service/CredentialService.php
+++ b/lib/Service/CredentialService.php
@@ -36,116 +36,147 @@ use OCA\Passman\Db\CredentialMapper;
 class CredentialService {
 
 	private $credentialMapper;
-    private $sharingACL;
+	private $sharingACL;
+	private $encryptService;
+	private $server_key;
 
-	public function __construct(CredentialMapper $credentialMapper, SharingACLMapper $sharingACL) {
+	public function __construct(CredentialMapper $credentialMapper, SharingACLMapper $sharingACL, EncryptService $encryptService) {
 		$this->credentialMapper = $credentialMapper;
-        $this->sharingACL = $sharingACL;
+		$this->sharingACL = $sharingACL;
+		$this->encryptService = $encryptService;
+		$this->server_key = \OC::$server->getConfig()->getSystemValue('passwordsalt', '');
 	}
 
 	/**
 	 * Create a new credential
+	 *
 	 * @param $user_id
 	 * @param $item_guid
 	 * @return Credential
 	 */
 	public function createCredential($credential) {
+		$credential = $this->encryptService->encryptCredential($credential);
 		return $this->credentialMapper->create($credential);
 	}
 
 	/**
 	 * Update credential
+	 *
 	 * @param $credential array
 	 * @return Credential
 	 */
 	public function updateCredential($credential) {
+		$credential = $this->encryptService->encryptCredential($credential);
 		return $this->credentialMapper->updateCredential($credential);
 	}
 
 	/**
 	 * Update credential
+	 *
 	 * @param $credential Credential
+	 * @return Credential
 	 */
 	public function upd(Credential $credential) {
-		return $this->credentialMapper->upd($credential);
+		$credential = $this->encryptService->encryptCredential($credential);
+		return $this->credentialMapper->updateCredential($credential);
 	}
 
 	/**
 	 * Delete credential
+	 *
 	 * @param Credential $credential
 	 * @return \OCP\AppFramework\Db\Entity
 	 */
-	public function deleteCredential(Credential $credential){
+	public function deleteCredential(Credential $credential) {
 		return $this->credentialMapper->deleteCredential($credential);
 	}
 
 	/**
 	 * Get credentials by vault id
+	 *
 	 * @param $vault_id
 	 * @param $user_id
-	 * @return \OCA\Passman\Db\Vault[]
+	 * @return \OCA\Passman\Db\Credential[]
 	 */
 	public function getCredentialsByVaultId($vault_id, $user_id) {
-		return $this->credentialMapper->getCredentialsByVaultId($vault_id, $user_id);
+		$credentials = $this->credentialMapper->getCredentialsByVaultId($vault_id, $user_id);
+		foreach ($credentials as $index => $credential) {
+			$credentials[$index] = $this->encryptService->decryptCredential($credential);
+		}
+		return $credentials;
 	}
 
 	/**
 	 * Get a random credential from given vault
+	 *
 	 * @param $vault_id
 	 * @param $user_id
 	 * @return mixed
 	 */
 	public function getRandomCredentialByVaultId($vault_id, $user_id) {
 		$credentials = $this->credentialMapper->getRandomCredentialByVaultId($vault_id, $user_id);
+		foreach ($credentials as $index => $credential) {
+			$credentials[$index] = $this->encryptService->decryptCredential($credential);
+		}
 		return array_pop($credentials);
 	}
 
 	/**
 	 * Get expired credentials.
+	 *
 	 * @param $timestamp
 	 * @return \OCA\Passman\Db\Credential[]
 	 */
 	public function getExpiredCredentials($timestamp) {
-		return $this->credentialMapper->getExpiredCredentials($timestamp);
+		$credentials = $this->credentialMapper->getExpiredCredentials($timestamp);
+		foreach ($credentials as $index => $credential) {
+			$credentials[$index] = $this->encryptService->decryptCredential($credential);
+		}
+		return $credentials;
 	}
 
 	/**
 	 * Get a single credential.
+	 *
 	 * @param $credential_id
 	 * @param $user_id
 	 * @return Credential
 	 * @throws DoesNotExistException
 	 */
-	public function getCredentialById($credential_id, $user_id){
-        $credential = $this->credentialMapper->getCredentialById($credential_id);
-        if ($credential->getUserId() === $user_id){
-            return $credential;
-        }
-        else {
-            $acl = $this->sharingACL->getItemACL($user_id, $credential->getGuid());
-            if ($acl->hasPermission(SharingACL::READ)) {
-				return $credential;
+	public function getCredentialById($credential_id, $user_id) {
+		$credential = $this->credentialMapper->getCredentialById($credential_id);
+		if ($credential->getUserId() === $user_id) {
+			return $credential;
+		} else {
+			$acl = $this->sharingACL->getItemACL($user_id, $credential->getGuid());
+			if ($acl->hasPermission(SharingACL::READ)) {
+				return $this->encryptService->decryptCredential($credential);
 			}
 			throw new DoesNotExistException("Did expect one result but found none when executing");
-        }
+
+		}
 	}
 
 	/**
 	 * Get credential label by credential id.
+	 *
 	 * @param $credential_id
 	 * @return Credential
 	 */
-	public function getCredentialLabelById($credential_id){
-		return $this->credentialMapper->getCredentialLabelById($credential_id);
+	public function getCredentialLabelById($credential_id) {
+		$credential = $this->credentialMapper->getCredentialLabelById($credential_id);
+		return $this->encryptService->decryptCredential($credential);
 	}
 
 	/**
 	 * Get credential by guid
+	 *
 	 * @param $credential_guid
 	 * @param null $user_id
 	 * @return Credential
 	 */
-	public function getCredentialByGUID($credential_guid, $user_id = null){
-	    return $this->credentialMapper->getCredentialByGUID($credential_guid, $user_id);
-    }
+	public function getCredentialByGUID($credential_guid, $user_id = null) {
+		$credential = $this->credentialMapper->getCredentialByGUID($credential_guid, $user_id);
+		return $this->encryptService->decryptCredential($credential);
+	}
 }

--- a/lib/Service/CredentialService.php
+++ b/lib/Service/CredentialService.php
@@ -50,8 +50,7 @@ class CredentialService {
 	/**
 	 * Create a new credential
 	 *
-	 * @param $user_id
-	 * @param $item_guid
+	 * @param array $credential
 	 * @return Credential
 	 */
 	public function createCredential($credential) {
@@ -152,8 +151,6 @@ class CredentialService {
 			if ($acl->hasPermission(SharingACL::READ)) {
 				return $this->encryptService->decryptCredential($credential);
 			}
-			throw new DoesNotExistException("Did expect one result but found none when executing");
-
 		}
 	}
 

--- a/lib/Service/CredentialService.php
+++ b/lib/Service/CredentialService.php
@@ -150,6 +150,8 @@ class CredentialService {
 			$acl = $this->sharingACL->getItemACL($user_id, $credential->getGuid());
 			if ($acl->hasPermission(SharingACL::READ)) {
 				return $this->encryptService->decryptCredential($credential);
+			} else {
+				throw new DoesNotExistException("Did expect one result but found none when executing");
 			}
 		}
 	}

--- a/lib/Service/EncryptService.php
+++ b/lib/Service/EncryptService.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Nextcloud - passman
+ *
+ * @copyright Copyright (c) 2016, Sander Brand (brantje@gmail.com)
+ * @copyright Copyright (c) 2016, Marcos Zuriaga Miguel (wolfi@wolfi.es)
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Passman\Service;
+
+
+// Class copied from http://stackoverflow.com/questions/5089841/two-way-encryption-i-need-to-store-passwords-that-can-be-retrieved?answertab=votes#tab-top
+// Upgraded to use openssl
+class EncryptService {
+
+	/**
+	 * Supported cipher algorithms accompanied by their key/block sizes in bytes
+	 *
+	 * OpenSSL has no equivalent of mcrypt_get_key_size() and mcrypt_get_block_size() hence sizes stored here.
+	 *
+	 * @var array
+	 */
+	protected $supportedAlgos = array(
+		'aes-256' => array('name' => 'AES-256', 'keySize' => 32, 'blockSize' => 32),
+		'bf' => array('name' => 'BF', 'keySize' => 16, 'blockSize' => 8),
+		'des' => array('name' => 'DES', 'keySize' => 7, 'blockSize' => 8),
+		'des-ede3' => array('name' => 'DES-EDE3', 'keySize' => 21, 'blockSize' => 8), // 3 different 56-bit keys
+		'cast5' => array('name' => 'CAST5', 'keySize' => 16, 'blockSize' => 8),
+	);
+
+	/**
+	 * Supported encryption modes
+	 *
+	 * @var array
+	 */
+	protected $supportedModes = array(
+		'cbc' => 'CBC',
+	);
+
+	/**
+	 * A class to handle secure encryption and decryption of arbitrary data
+	 *
+	 *  Note that this is not just straight encryption. It also has a few other
+	 *  features in it to make the encrypted data far more secure.  Note that any
+	 *  other implementations used to decrypt data will have to do the same exact
+	 *  operations.
+	 *
+	 * Security Benefits:
+	 *
+	 * - Uses Key stretching
+	 * - Hides the Initialization Vector
+	 * - Does HMAC verification of source data
+	 *
+	 */
+
+	/**
+	 * Create an encryption key. Based on given parameters
+	 *
+	 * @param string $userKey The user key to use. This should be specific to this user.
+	 * @param string $serverKey The server key
+	 * @param string $userSuppliedKey A key from the credential (eg guid, name or tags)
+	 * @return string
+	 */
+
+	public static function makeKey($userKey, $serverKey, $userSuppliedKey) {
+		$key = hash_hmac('sha512', $userKey, $serverKey);
+		$key = hash_hmac('sha512', $key, $userSuppliedKey);
+		return $key;
+	}
+
+	/**
+	 * @var string $cipher The mcrypt cipher to use for this instance
+	 */
+	protected $cipher = '';
+
+	/**
+	 * @var int $mode The mcrypt cipher mode to use
+	 */
+	protected $mode = '';
+
+	/**
+	 * @var int $rounds The number of rounds to feed into PBKDF2 for key generation
+	 */
+	protected $rounds = 100;
+
+	/**
+	 * Constructor!
+	 *
+	 * @param string $cipher The MCRYPT_* cypher to use for this instance
+	 * @param int $mode The MCRYPT_MODE_* mode to use for this instance
+	 * @param int $rounds The number of PBKDF2 rounds to do on the key
+	 */
+	public function __construct($cipher, $mode, $rounds = 100) {
+		$this->cipher = $cipher;
+		$this->mode = $mode;
+		$this->rounds = (int)$rounds;
+	}
+
+	/**
+	 * Get the maximum key size for the selected cipher and mode of operation
+	 *
+	 * @return int Value is in bytes
+	 */
+	public function getKeySize() {
+		return $this->supportedAlgos[$this->cipher]['keySize'];
+	}
+
+	/**
+	 * Decrypt the data with the provided key
+	 *
+	 * @param string $data_hex The encrypted datat to decrypt
+	 * @param string $key The key to use for decryption
+	 *
+	 * @returns string|false The returned string if decryption is successful
+	 *                           false if it is not
+	 */
+	public function decrypt($data_hex, $key) {
+
+		if (!function_exists('hex2bin')) {
+			function hex2bin($str) {
+				$sbin = "";
+				$len = strlen($str);
+				for ($i = 0; $i < $len; $i += 2) {
+					$sbin .= pack("H*", substr($str, $i, 2));
+				}
+
+				return $sbin;
+			}
+		}
+
+		$data = hex2bin($data_hex);
+
+		$salt = substr($data, 0, 128);
+		$enc = substr($data, 128, -64);
+		$mac = substr($data, -64);
+
+		list ($cipherKey, $macKey, $iv) = $this->getKeys($salt, $key);
+
+		if (!EncryptService::hash_equals(hash_hmac('sha512', $enc, $macKey, true), $mac)) {
+			return false;
+		}
+
+		$dec = openssl_decrypt($enc, $this->cipher . '-' . $this->mode, $cipherKey, true, $iv);
+		$data = $this->unpad($dec);
+
+		return $data;
+	}
+
+	/**
+	 * Encrypt the supplied data using the supplied key
+	 *
+	 * @param string $data The data to encrypt
+	 * @param string $key The key to encrypt with
+	 *
+	 * @returns string The encrypted data
+	 */
+	public function encrypt($data, $key) {
+		$salt = openssl_random_pseudo_bytes(128);
+		list ($cipherKey, $macKey, $iv) = EncryptService::getKeys($salt, $key);
+		$data = EncryptService::pad($data);
+		$enc = openssl_encrypt($data, $this->cipher . '-' . $this->mode, $cipherKey, true, $iv);
+
+
+		$mac = hash_hmac('sha512', $enc, $macKey, true);
+
+		$data = bin2hex($salt . $enc . $mac);
+		return $data;
+
+	}
+
+	/**
+	 * Generates a set of keys given a random salt and a master key
+	 *
+	 * @param string $salt A random string to change the keys each encryption
+	 * @param string $key The supplied key to encrypt with
+	 *
+	 * @returns array An array of keys (a cipher key, a mac key, and a IV)
+	 */
+	protected function getKeys($salt, $key) {
+		$ivSize = openssl_cipher_iv_length($this->cipher . '-' . $this->mode);
+		$keySize = openssl_cipher_iv_length($this->cipher . '-' . $this->mode);
+		$length = 2 * $keySize + $ivSize;
+
+		$key = EncryptService::pbkdf2('sha512', $key, $salt, $this->rounds, $length);
+
+		$cipherKey = substr($key, 0, $keySize);
+		$macKey = substr($key, $keySize, $keySize);
+		$iv = substr($key, 2 * $keySize);
+		return array($cipherKey, $macKey, $iv);
+	}
+
+	function hash_equals($a, $b) {
+		$key = openssl_random_pseudo_bytes(128);
+		return hash_hmac('sha512', $a, $key) === hash_hmac('sha512', $b, $key);
+	}
+
+	/**
+	 * Stretch the key using the PBKDF2 algorithm
+	 *
+	 * @see http://en.wikipedia.org/wiki/PBKDF2
+	 *
+	 * @param string $algo The algorithm to use
+	 * @param string $key The key to stretch
+	 * @param string $salt A random salt
+	 * @param int $rounds The number of rounds to derive
+	 * @param int $length The length of the output key
+	 *
+	 * @returns string The derived key.
+	 */
+	protected function pbkdf2($algo, $key, $salt, $rounds, $length) {
+		$size = strlen(hash($algo, '', true));
+		$len = ceil($length / $size);
+		$result = '';
+		for ($i = 1; $i <= $len; $i++) {
+			$tmp = hash_hmac($algo, $salt . pack('N', $i), $key, true);
+			$res = $tmp;
+			for ($j = 1; $j < $rounds; $j++) {
+				$tmp = hash_hmac($algo, $tmp, $key, true);
+				$res ^= $tmp;
+			}
+			$result .= $res;
+		}
+		return substr($result, 0, $length);
+	}
+
+	/**
+	 * Pad the data with a random char chosen by the pad amount.
+	 *
+	 * @param $data
+	 * @return string
+	 */
+	protected function pad($data) {
+		$length = $this->getKeySize();
+		$padAmount = $length - strlen($data) % $length;
+		if ($padAmount == 0) {
+			$padAmount = $length;
+		}
+		return $data . str_repeat(chr($padAmount), $padAmount);
+	}
+
+
+	/**
+	 * Unpad the the data
+	 *
+	 * @param $data
+	 * @return bool|string
+	 */
+	protected function unpad($data) {
+		$length = $this->getKeySize();
+		$last = ord($data[strlen($data) - 1]);
+		if ($last > $length) return false;
+		if (substr($data, -1 * $last) !== str_repeat(chr($last), $last)) {
+			return false;
+		}
+		return substr($data, 0, -1 * $last);
+	}
+}

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -54,6 +54,7 @@ class SettingsService {
 			'check_version' => intval($this->config->getAppValue('passman', 'check_version', 1)),
 			'https_check' => intval($this->config->getAppValue('passman', 'https_check', 1)),
 			'disable_contextmenu' => intval($this->config->getAppValue('passman', 'disable_contextmenu', 1)),
+			'server_side_encryption' => $this->config->getAppValue('passman', 'server_side_encryption', 'aes-256-cbc'),
 			'settings_loaded' => 1
 		);
 	}

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -55,6 +55,7 @@ class SettingsService {
 			'https_check' => intval($this->config->getAppValue('passman', 'https_check', 1)),
 			'disable_contextmenu' => intval($this->config->getAppValue('passman', 'disable_contextmenu', 1)),
 			'server_side_encryption' => $this->config->getAppValue('passman', 'server_side_encryption', 'aes-256-cbc'),
+			'rounds_pbkdf2_stretching' => $this->config->getAppValue('passman', 'rounds_pbkdf2_stretching', 100),
 			'settings_loaded' => 1
 		);
 	}

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -42,12 +42,13 @@ class ShareService {
 	private $encryptService;
 
 	private $server_key;
+
 	public function __construct(
 		SharingACLMapper $sharingACL,
 		ShareRequestMapper $shareRequest,
 		CredentialMapper $credentials,
 		CredentialRevisionService $revisions,
-	    EncryptService $encryptService
+		EncryptService $encryptService
 	) {
 		$this->sharingACL = $sharingACL;
 		$this->shareRequest = $shareRequest;
@@ -159,6 +160,7 @@ class ShareService {
 
 	/**
 	 * Gets the acl for a given item guid
+	 *
 	 * @param $user_id
 	 * @param $item_guid
 	 * @return SharingACL
@@ -200,31 +202,33 @@ class ShareService {
 	}
 
 
-    /**
-     * Deletes a share request by the item ID
-     * @param ShareRequest $request
-     * @return \PDOStatement
-     */
+	/**
+	 * Deletes a share request by the item ID
+	 *
+	 * @param ShareRequest $request
+	 * @return \PDOStatement
+	 */
 	public function cleanItemRequestsForUser(ShareRequest $request) {
 		return $this->shareRequest->cleanItemRequestsForUser($request->getItemId(), $request->getTargetUserId());
 	}
 
-    /**
-     * Get an share request by id
-     * @param $id
-     * @return ShareRequest
-     */
+	/**
+	 * Get an share request by id
+	 *
+	 * @param $id
+	 * @return ShareRequest
+	 */
 	public function getShareRequestById($id) {
 		return $this->shareRequest->getShareRequestById($id);
 	}
 
-    /**
-     * Get an share request by $item_guid and $target_vault_guid
-     *
-     * @param $item_guid
-     * @param $target_vault_guid
-     * @return ShareRequest
-     */
+	/**
+	 * Get an share request by $item_guid and $target_vault_guid
+	 *
+	 * @param $item_guid
+	 * @param $target_vault_guid
+	 * @return ShareRequest
+	 */
 	public function getRequestByGuid($item_guid, $target_vault_guid) {
 		return $this->shareRequest->getRequestByItemAndVaultGuid($item_guid, $target_vault_guid);
 	}
@@ -284,11 +288,12 @@ class ShareService {
 		return $this->sharingACL->deleteShareACL($ACL);
 	}
 
-    /**
-     * Updates the given ACL entry
-     * @param SharingACL $sharingACL
-     * @return SharingACL
-     */
+	/**
+	 * Updates the given ACL entry
+	 *
+	 * @param SharingACL $sharingACL
+	 * @return SharingACL
+	 */
 	public function updateCredentialACL(SharingACL $sharingACL) {
 		return $this->sharingACL->updateCredentialACL($sharingACL);
 	}
@@ -309,7 +314,7 @@ class ShareService {
 	}
 
 
-	public function updatePendingShareRequestsForCredential($item_guid, $user_id, $permissions){
-	    return $this->shareRequest->updatePendingRequestPermissions($item_guid, $user_id, $permissions);
-    }
+	public function updatePendingShareRequestsForCredential($item_guid, $user_id, $permissions) {
+		return $this->shareRequest->updatePendingRequestPermissions($item_guid, $user_id, $permissions);
+	}
 }

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -41,7 +41,6 @@ class ShareService {
 	private $revisions;
 	private $encryptService;
 
-	private $server_key;
 
 	public function __construct(
 		SharingACLMapper $sharingACL,
@@ -55,7 +54,6 @@ class ShareService {
 		$this->credential = $credentials;
 		$this->revisions = $revisions;
 		$this->encryptService = $encryptService;
-		$this->server_key = \OC::$server->getConfig()->getSystemValue('passwordsalt', '');
 	}
 
 	/**

--- a/migration/serversideencryption.php
+++ b/migration/serversideencryption.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Nextcloud - passman
+ *
+ * @copyright Copyright (c) 2016, Sander Brand (brantje@gmail.com)
+ * @copyright Copyright (c) 2016, Marcos Zuriaga Miguel (wolfi@wolfi.es)
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Passman\Migration;
+
+use OCA\Passman\Db\CredentialRevision;
+use OCA\Passman\Service\CredentialRevisionService;
+use OCA\Passman\Service\CredentialService;
+use OCA\Passman\Service\EncryptService;
+use OCA\Passman\Service\FileService;
+use OCP\IDBConnection;
+use OCP\ILogger;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+
+class ServerSideEncryption implements IRepairStep {
+
+	/** @var encryptService */
+	private $encryptService;
+
+	/** @var IDBConnection */
+	private $db;
+
+	/** @var string */
+	private $installedVersion;
+
+	/** @var ILogger */
+	private $logger;
+
+	/** @var CredentialService */
+	private $credentialService;
+
+	/** @var  CredentialRevisionService */
+	private $revisionService;
+
+	/** @var FileService */
+	private $fileService;
+
+	public function __construct(EncryptService $encryptService, IDBConnection $db, ILogger $logger, CredentialService $credentialService, CredentialRevisionService $revisionService,
+								FileService $fileService) {
+		$this->encryptService = $encryptService;
+		$this->db = $db;
+		$this->logger = $logger;
+		$this->credentialService = $credentialService;
+		$this->revisionService = $revisionService;
+		$this->fileService = $fileService;
+		$this->installedVersion = \OC::$server->getConfig()->getAppValue('passman', 'installed_version');
+	}
+
+	public function getName() {
+		return 'Enabling server side encryption for passman';
+	}
+
+	public function run(IOutput $output) {
+		if (version_compare($this->installedVersion, '2.0.0RC4', '<')) {
+			$this->encryptCredentials();
+			$this->encryptRevisions();
+			$this->encryptFiles();
+		}
+	}
+
+	private function encryptCredentials() {
+		$credentials = $this->db->executeQuery('SELECT * FROM `*PREFIX*passman_credentials`')->fetchAll();
+		foreach ($credentials as $credential) {
+			$this->credentialService->updateCredential($credential);
+		}
+	}
+
+	private function encryptRevisions() {
+		$revisions = $this->db->executeQuery('SELECT * FROM `*PREFIX*passman_revisions`')->fetchAll();
+		foreach ($revisions as $_revision) {
+			$revision = new CredentialRevision();
+			$revision->setId($_revision['id']);
+			$revision->setGuid($_revision['guid']);
+			$revision->setCredentialId($_revision['credential_id']);
+			$revision->setUserId($_revision['user_id']);
+			$revision->setCreated($_revision['created']);
+			$revision->setEditedBy($_revision['edited_by']);
+			$revision->setCredentialData( $_revision['credential_data']);
+			$this->revisionService->updateRevision($revision);
+		}
+	}
+
+	private function encryptFiles() {
+		$files = $this->db->executeQuery('SELECT * FROM `*PREFIX*passman_files`')->fetchAll();
+		foreach ($files as $file) {
+			$this->fileService->updateFile($file);
+		}
+	}
+}

--- a/templates/part.admin.php
+++ b/templates/part.admin.php
@@ -31,7 +31,7 @@ $ciphers = openssl_get_cipher_methods();
 		<h2><?php p($l->t('Passman Settings')); ?></h2>
 		<?php
 		if ($checkVersion) {
-			p($l->t('Github version:'). ' '. $githubVersion);
+			p($l->t('Github version:') . ' ' . $githubVersion);
 			print '<br />';
 		} ?>
 		Local version: <?php p($localVersion); ?><br/>
@@ -53,7 +53,7 @@ $ciphers = openssl_get_cipher_methods();
 		<p>
 			<input type="checkbox" name="passman_sharing_enabled"
 				   id="passman_sharing_enabled" class="checkbox"
-				   value="1" />
+				   value="1"/>
 			<label for="passman_sharing_enabled">
 				<?php p($l->t('Allow users on this server to share passwords with other users')); ?>
 			</label>
@@ -102,12 +102,13 @@ $ciphers = openssl_get_cipher_methods();
 		</p>
 		<p>
 
-			<label for="server_side_encryption">Server side encryption method:</label>
+			<label for="server_side_encryption">Server side encryption
+				method:</label>
 			<select name="server_side_encryption2" id="server_side_encryption2">
 				<?php
-					foreach ($ciphers as $cipher){
-						print '<option value="'. $cipher .'">'. $cipher .'</option>';
-					}
+				foreach ($ciphers as $cipher) {
+					print '<option value="' . $cipher . '">' . $cipher . '</option>';
+				}
 				?>
 			</select> (Not working atm. OpenSSL has no equivalent of <code>mcrypt_get_key_size()</code>)
 		</p>

--- a/templates/part.admin.php
+++ b/templates/part.admin.php
@@ -23,6 +23,7 @@ if ($checkVersion) {
 		$githubVersion = $version;
 	}
 }
+$ciphers = openssl_get_cipher_methods();
 ?>
 
 <div id="passwordSharingSettings" class="followup section">
@@ -98,6 +99,17 @@ if ($checkVersion) {
 					Strong
 				</option>
 			</select>
+		</p>
+		<p>
+
+			<label for="server_side_encryption">Server side encryption method:</label>
+			<select name="server_side_encryption2" id="server_side_encryption2">
+				<?php
+					foreach ($ciphers as $cipher){
+						print '<option value="'. $cipher .'">'. $cipher .'</option>';
+					}
+				?>
+			</select> (Not working atm. OpenSSL has no equivalent of <code>mcrypt_get_key_size()</code>)
 		</p>
 	</form>
 </div>

--- a/tests/unit/controller/VaultControllerTest.php
+++ b/tests/unit/controller/VaultControllerTest.php
@@ -24,6 +24,7 @@
 namespace OCA\Passman\Controller;
 
 use OCA\Passman\Service\CredentialService;
+use OCA\Passman\Service\SettingsService;
 use OCA\Passman\Service\VaultService;
 use PHPUnit_Framework_TestCase;
 
@@ -46,9 +47,10 @@ class VaultControllerTest extends PHPUnit_Framework_TestCase {
 		$request = $this->getMockBuilder('OCP\IRequest')->getMock();
 		$this->vaultService = $this->createMock(VaultService::class);
 		$this->credentialService = $this->createMock(CredentialService::class);
+		$this->settingsService = $this->createMock(SettingsService::class);
 
 		$this->controller = new VaultController(
-			'passman', $request, $this->userId, $this->vaultService, $this->credentialService
+			'passman', $request, $this->userId, $this->vaultService, $this->credentialService, $this->settingsService
 		);
 	}
 

--- a/tests/unit/lib/Service/EncryptServiceTest.php
+++ b/tests/unit/lib/Service/EncryptServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Nextcloud - passman
+ *
+ * @copyright Copyright (c) 2016, Sander Brand (brantje@gmail.com)
+ * @copyright Copyright (c) 2016, Marcos Zuriaga Miguel (wolfi@wolfi.es)
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Passman\Controller;
+
+use OCA\Passman\Service\EncryptService;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use PHPUnit_Framework_TestCase;
+use OCA\Passman\Service\SettingsService;
+
+/**
+ * Class SettingsServiceTest
+ *
+ * @package OCA\Passman\Controller
+ * @coversDefaultClass  \OCA\Passman\Service\EncryptService
+ */
+class EncryptServiceTest extends PHPUnit_Framework_TestCase {
+
+	private $service;
+	private $testKey;
+
+	public function setUp() {
+		$config = $this->getMockBuilder('OCP\IConfig')->getMock();
+		$userId = 'admin';
+		$settings_service = new SettingsService($userId, $config, 'passman');
+		$this->service = new EncryptService($settings_service);
+
+	}
+
+	/**
+	 * @covers ::testMakeKey
+	 */
+	public function testMakeKey() {
+		$this->testKey = $this->service->makeKey('userKey', 'serverKey', 'userSuppliedKey');
+		$this->assertTrue($this->testKey === '967efb38599fb81ebc95b280e7c86cda0593e469f6a391caf9e9fee7c3976fd1edcdeefdb6a99e9f0bc47fda4b77fb8309c1955211dccf1dab1aad00c2ad5656');
+	}
+}


### PR DESCRIPTION
This improves the general security of passman by encrypting the credentials again, but this time on the server side. It used AES-256 as cipher with CBC as method.
- Key is stretched using the [PBKDF2](http://en.wikipedia.org/wiki/PBKDF2) algorithm.
- Hides the Initialization Vector
- Does HMAC verification of source data

Todo:
- [x] Add update script to convert passwords prior to RC4 
- [x] Add `<lib>openssl</lib>` under `<dependencies>`