### PR TITLE
Add hash_equals

### DIFF
--- a/controller/credentialcontroller.php
+++ b/controller/credentialcontroller.php
@@ -142,7 +142,7 @@ class CredentialController extends ApiController {
 		);
 
 
-		if ($storedCredential->getUserId() !== $this->userId) {
+		if (!hash_equals($storedCredential->getUserId(), $this->userId)) {
 			$acl = $this->sharingService->getCredentialAclForUser($this->userId, $storedCredential->getGuid());
 			if ($acl->hasPermission(SharingACL::WRITE)) {
 				$credential['shared_key'] = $storedCredential->getSharedKey();
@@ -219,7 +219,7 @@ class CredentialController extends ApiController {
 					'', array(),
 					$link, $target_user, Activity::TYPE_ITEM_ACTION);
 			}
-			if ($this->userId !== $storedCredential->getUserId()) {
+			if (!hash_equals($this->userId, $storedCredential->getUserId())) {
 				$this->activityService->add(
 					$activity, $params,
 					'', array(),


### PR DESCRIPTION
The `!==` operation does a byte-by-byte comparison of two values and as soon as the two differentiate it terminates. Using this method can make you application vulnerable to [timing attacks](https://codahale.com/a-lesson-in-timing-attacks/).

`hash_equals` is a time independent comparison function and it does not terminate as soon as two bytes are not the same.