### PR TITLE
update flattr link for flattr 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Passman is open source, and we would gladly accept a beer (or pizza!)
 Please consider donating
 - [PayPal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=6YS8F97PETVU2)
 - [Patreon](https://www.patreon.com/user?u=4833592)
-- [Flattr](https://flattr.com/profile/passman)
+- [Flattr](https://flattr.com/@passman)
 - bitcoin: 1H2c5tkGX54n48yEtM4Wm4UrAGTW85jQpe
 
 ## Code reviews


### PR DESCRIPTION
as flattr updatet to 2.0 - links changed
also the way flattrs are handled changed
think of linking your github profile(s) and passman.cc to flattr