### PR TITLE
add link to nextcloud server wiki on how to sign commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 If you want to contribute make sure the commits are `verified`.   
 You can read how to GPG sign you commits [here](https://help.github.com/articles/signing-commits-using-gpg/).
+And read how to set up a PGP key for commit signing in the [nextcloud server wiki](https://github.com/nextcloud/server/wiki/How-to-sign-your-commits-using-PGP).
 
 Issue's / Feature requests not honoring the template will be closed instantly.


### PR DESCRIPTION
just as an idea because this documentation helped me a lot setting up my pgp key for git signing