### PR TITLE
Removed overflow-x, so that scrolling and swiping does not break mobile ui

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -32,6 +32,9 @@
 @import 'share_credential';
 @import 'settings';
 
+.app-passman{
+  overflow-x: hidden;
+}
 
 .template-hidden{
   display: none !important;


### PR DESCRIPTION
Removed overflow-x, so that scrolling and swiping does not break mobile ui

Signed-off-by: fnuesse <felix.nuesse@t-online.de>

closes #525