### PR TITLE
Allow inline style and srcipt eval in NC 15

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -43,6 +43,7 @@ class PageController extends Controller {
 
 		$csp = new StrictContentSecurityPolicy();
 		$csp->allowEvalScript();
+        $csp->allowInlineStyle();
 
 		$response->setContentSecurityPolicy($csp);
 

--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -39,14 +39,14 @@ class PageController extends Controller {
 	 */
 	public function index() {
 		$params = ['user' => $this->userId];
-        $response = new TemplateResponse('passman', 'main', $params);  // templates/main.php
+		$response = new TemplateResponse('passman', 'main', $params);  // templates/main.php
 
-        $csp        = new StrictContentSecurityPolicy();
-        $csp->allowEvalScript();
+		$csp = new StrictContentSecurityPolicy();
+		$csp->allowEvalScript();
 
-        $response->setContentSecurityPolicy($csp);
+		$response->setContentSecurityPolicy($csp);
 
-        return $response;
+		return $response;
 	}
 
 

--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -11,6 +11,7 @@
 
 namespace OCA\Passman\Controller;
 
+use OCP\AppFramework\Http\StrictContentSecurityPolicy;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\DataResponse;
@@ -38,7 +39,14 @@ class PageController extends Controller {
 	 */
 	public function index() {
 		$params = ['user' => $this->userId];
-		return new TemplateResponse('passman', 'main', $params);  // templates/main.php
+        $response = new TemplateResponse('passman', 'main', $params);  // templates/main.php
+
+        $csp        = new StrictContentSecurityPolicy();
+        $csp->allowEvalScript();
+
+        $response->setContentSecurityPolicy($csp);
+
+        return $response;
 	}
 
 


### PR DESCRIPTION
If you open the debugging tools while using Passman you see a lot of Content-Security-Policy errors because Nextcloud 15 does no longer allow eval and inline css by default. This patch adds a custom CSP which allows this and resolves the issues.