### PR TITLE
Address #532 Cannot export passwords

### DIFF
--- a/js/exporters/exporter-csv.js
+++ b/js/exporters/exporter-csv.js
@@ -55,7 +55,12 @@ PassmanExporter.csv.export = function (credentials, FileService, EncryptService)
 					row_data.push('"' + _fields + '"');
 				    }
 				    else {
-					    row_data.push('"' + _credential[field].replaceAll('"', '""') + '"');
+					    if (_credential[field] != null) {
+						    row_data.push('"'+_credential[field].replaceAll('"','""')+'"');
+					    }
+					    else {
+						    row_data.push('""');
+					    }
 				    }
 			    }
 			    var progress = {


### PR DESCRIPTION
Some fields within the credential array were null so the call to replaceAll failed.
Wrapped this in a check and pushed an empty string in this case