### PR TITLE
Fix/589/import issues

### DIFF
--- a/js/importers/import-main.js
+++ b/js/importers/import-main.js
@@ -98,7 +98,8 @@ var PassmanImporter = {};
 			'files': [],
 			'custom_fields': [],
 			'otp': {},
-			'hidden': false
+			'hidden': false,
+			'compromised': false,
 		};
 		return credential;
 	};

--- a/js/importers/importer-keepasscsv.js
+++ b/js/importers/importer-keepasscsv.js
@@ -30,7 +30,7 @@ var PassmanImporter = PassmanImporter || {};
 		info: {
 			name: 'KeePass csv',
 			id: 'keepassCsv',
-			exportSteps: ['Create an csv export with the following options enabled: http://i.imgur.com/CaeTA4d.png']
+			exportSteps: ['If using Keepass V1: Create an csv export with the following options enabled: http://i.imgur.com/CaeTA4d.png', 'With Keepass V2 or Keepass XC no configuration is needed']
 		}
 	};
 


### PR DESCRIPTION
The `compromised` field of `credentials` object was not created by the importer, so there was an exception when encrypting the fields as `undefined` was pasted to the encryption library.

Should fix #589 

closes #589 