### PR TITLE
Escape reserved SQL keyword when notifying expired credentials.

### DIFF
--- a/lib/Service/CronService.php
+++ b/lib/Service/CronService.php
@@ -52,7 +52,7 @@ class CronService {
 		foreach($expired_credentials as $credential){
 			$link = ''; // @TODO create direct link to credential
 
-			$sql = 'SELECT count(*) as rows from `*PREFIX*notifications` WHERE `subject`= \'credential_expired\' AND object_id=?';
+			$sql = 'SELECT count(*) as `rows` from `*PREFIX*notifications` WHERE `subject`= \'credential_expired\' AND object_id=?';
 			$id = $credential->getId();
 			$result = $this->db->executeQuery($sql, array($id));
 			$this->logger->debug($credential->getLabel() .' is expired, checking notifications!', array('app' => 'passman'));


### PR DESCRIPTION
The CronService fails to send notifications for expired credentials
due to the SQL query containing as a column name the word 'rows',
which is a reserved keyword. This is the cause of issue #490.

This patch fixes the issue simply by quoting the offending keyword.

Signed-off-by: Damien Goutte-Gattat <dgouttegattat@incenp.org>