### PR TITLE
Change text of Compromise button to Mark as Compromised

### DIFF
--- a/controller/translationcontroller.php
+++ b/controller/translationcontroller.php
@@ -425,7 +425,7 @@ class TranslationController extends ApiController {
 			'expired.share' => $this->trans->t('Awwhh… credential not found. Maybe it expired'),
 
 			//compromised credentials
-			'compromised.label' => $this->trans->t('Compromise!'),
+			'compromised.label' => $this->trans->t('Mark as Compromised'),
 			'compromised.warning.list' => $this->trans->t('Compromised!'),
 			'compromised.warning' => $this->trans->t('This password is compromised. You can only remove this warning by changing the password.'),
 


### PR DESCRIPTION
As mentioned in https://github.com/nextcloud/passman/issues/599#event-2397570661

Changed text to make the purpose of the button clearer. Instead of "Compromise!" which many users read as the password having been identified as being compromised, the button now reads "Mark as Compromised"