### PR TITLE
Bump max Nextcloud version to 19 and ownCloud to 10.  Fixes #659 #660 #661.

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,8 +42,8 @@ For an demo of this app visit [https://demo.passman.cc](https://demo.passman.cc)
         <database>pgsql</database>
         <database min-version="5.5">mysql</database>
         <lib>openssl</lib>
-        <nextcloud min-version="17" max-version="18"/>
-        <owncloud min-version="17" max-version="18"/>
+        <nextcloud min-version="17" max-version="19"/>
+        <owncloud min-version="17" max-version="19"/>
     </dependencies>
 
     <background-jobs>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ For an demo of this app visit [https://demo.passman.cc](https://demo.passman.cc)
         <database min-version="5.5">mysql</database>
         <lib>openssl</lib>
         <nextcloud min-version="17" max-version="19"/>
-        <owncloud min-version="17" max-version="19"/>
+        <owncloud min-version="10" max-version="10"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
Increases max supported Nextcloud server major version to 19.

Fixes https://github.com/nextcloud/passman/issues/660 https://github.com/nextcloud/passman/issues/659  https://github.com/nextcloud/passman/issues/661