### PR TITLE
chore(npm-build): fix npm vulnerable build packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "karma-verbose-reporter": "0.0.3"
   },
   "dependencies": {
-    "grunt": "~1.0.3",
+    "grunt": "^1.4.1",
     "grunt-cli": "^1.3.2",
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-concat": "^1.0.1",


### PR DESCRIPTION
Fixed npm vulnerable grunt packages on the build setup, should not affect the final product,
but it kept github unhappy, and i don't like known vulnerable points, so there's that.