### PR TITLE
Make all passwords invisible in vault info

### DIFF
--- a/js/app/controllers/edit_credential.js
+++ b/js/app/controllers/edit_credential.js
@@ -311,7 +311,7 @@
 					}
 
 					if ($scope.new_custom_field.label && $scope.new_custom_field.value) {
-						$scope.storedCredential.custom_fields.push(angular.copy($scope.new_custom_field));
+						$scope.addCustomField();
 					}
 
 					if ($scope.storedCredential.label === null || $scope.storedCredential.label.length === 0) {


### PR DESCRIPTION
Signed-off-by: Eduard Stromenko <estromenko@mail.ru>

---
Now all custom fields with type 'password' will be hidden by default.

Example (custom fields Password2 and 555 have type 'password'):

![1 pass](https://user-images.githubusercontent.com/48186405/133592000-179775c1-c62b-4f94-a8e1-c695dd53aaf9.png)

Closes: https://github.com/nextcloud/passman/issues/335