### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/js/app/directives/otp.js
+++ b/js/app/directives/otp.js
@@ -54,7 +54,7 @@
 					}
 
 					for (i = 0; i + 4 <= bits.length; i += 4) {
-						var chunk = bits.substr(i, 4);
+						var chunk = bits.slice(i, i + 4);
 						hex = hex + parseInt(chunk, 2).toString(16);
 					}
 					return hex.length % 2 ? hex + "0" : hex;
@@ -91,8 +91,8 @@
 							var hmacObj = new jsSHA(time, 'HEX');
 							var hmac = hmacObj.getHMAC(key, 'HEX', 'SHA-1', "HEX");
 							var offset = hex2dec(hmac.substring(hmac.length - 1));
-							var otp = (hex2dec(hmac.substr(offset * 2, 8)) & hex2dec('7fffffff')) + '';
-							otp = (otp).substr(otp.length - 6, 6);
+							var otp = (hex2dec(hmac.slice(offset * 2, offset * 2 + 8)) & hex2dec('7fffffff')) + '';
+							otp = (otp).slice(-6);
 							scope.otp = otp;
 
 						};

--- a/tests/unit/js/mocks/OC.js
+++ b/tests/unit/js/mocks/OC.js
@@ -20,10 +20,10 @@ if (typeof oc_webroot === "undefined") {
 	oc_webroot = location.pathname;
 	var pos = oc_webroot.indexOf('/index.php/');
 	if (pos !== -1) {
-		oc_webroot = oc_webroot.substr(0, pos);
+		oc_webroot = oc_webroot.slice(0, pos);
 	}
 	else {
-		oc_webroot = oc_webroot.substr(0, oc_webroot.lastIndexOf('/'));
+		oc_webroot = oc_webroot.substring(0, oc_webroot.lastIndexOf('/'));
 	}
 }
 if (typeof console === "undefined" || typeof console.log === "undefined") {
@@ -498,7 +498,7 @@ var OC={
 		}
 		pos = queryString.indexOf('?');
 		if (pos >= 0){
-			queryString = queryString.substr(pos + 1);
+			queryString = queryString.slice(pos + 1);
 		}
 		parts = queryString.replace(/\+/g, '%20').split('&');
 		for (var i = 0; i < parts.length; i++){
@@ -507,8 +507,8 @@ var OC={
 			pos = part.indexOf('=');
 			if (pos >= 0) {
 				components = [
-					part.substr(0, pos),
-					part.substr(pos + 1)
+					part.slice(0, pos),
+					part.slice(pos + 1)
 				];
 			}
 			else {
@@ -1432,8 +1432,8 @@ function humanFileSize(size, skipSmallSizes) {
 	if(order < 2){
 		relativeSize = parseFloat(relativeSize).toFixed(0);
 	}
-	else if(relativeSize.substr(relativeSize.length-2,2)==='.0'){
-		relativeSize=relativeSize.substr(0,relativeSize.length-2);
+	else if(relativeSize.slice(-2)==='.0'){
+		relativeSize=relativeSize.slice(0,-2);
 	}
 	return relativeSize + ' ' + readableFormat;
 }
@@ -1780,11 +1780,11 @@ OC.Util.History = {
 		var hash = window.location.hash,
 			pos = hash.indexOf('?');
 		if (pos >= 0) {
-			return hash.substr(pos + 1);
+			return hash.slice(pos + 1);
 		}
 		if (hash.length) {
 			// remove hash sign
-			return hash.substr(1);
+			return hash.slice(1);
 		}
 		return '';
 	},


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.