### PR TITLE
Fix Postgres sharing issue #581

### DIFF
--- a/lib/Db/ShareRequestMapper.php
+++ b/lib/Db/ShareRequestMapper.php
@@ -74,15 +74,14 @@ class ShareRequestMapper extends QBMapper {
 	 * @return Entity[]
 	 * @throws Exception
 	 */
-	public function getRequestsByItemGuidGroupedByUser(string $item_guid) {
+	public function getRequestsByItemGuid(string $item_guid) {
 		if (strtolower($this->db->getDatabasePlatform()->getName()) === 'mysql') {
 			$this->db->executeQuery("SET sql_mode = '';");
 		}
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from(self::TABLE_NAME)
-			->where($qb->expr()->eq('item_guid', $qb->createNamedParameter($item_guid, IQueryBuilder::PARAM_STR)))
-			->groupBy('target_user_id');
+			->where($qb->expr()->eq('item_guid', $qb->createNamedParameter($item_guid, IQueryBuilder::PARAM_STR)));
 
 		return $this->findEntities($qb);
 	}

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -290,7 +290,7 @@ class ShareService {
 	 * @throws Exception
 	 */
 	public function getCredentialPendingAclList(string $item_guid) {
-		return $this->shareRequest->getRequestsByItemGuidGroupedByUser($item_guid);
+		return $this->shareRequest->getRequestsByItemGuid($item_guid);
 	}
 
 	/**

--- a/tests/unit/lib/Db/ShareRequestMapperTest.php
+++ b/tests/unit/lib/Db/ShareRequestMapperTest.php
@@ -112,7 +112,7 @@ class ShareRequestMapperTest extends DatabaseHelperTest {
 	}
 
 	/**
-	 * @covers ::getRequestsByItemGuidGroupedByUser
+	 * @covers ::getRequestsByItemGuid
 	 */
 	public function testGetRequestsByItemGuidGroupedByUser() {
 		$dataset = $this->findInDataset(
@@ -121,7 +121,7 @@ class ShareRequestMapperTest extends DatabaseHelperTest {
 			$this->dataset->getRow(0)['item_guid']
 		);
 
-		$result = $this->mapper->getRequestsByItemGuidGroupedByUser($dataset[0]['item_guid']);
+		$result = $this->mapper->getRequestsByItemGuid($dataset[0]['item_guid']);
 
 		$this->assertCount(count($dataset), $result);
 


### PR DESCRIPTION
By removing the useless `group by`, we fix issue #581 

## The bug

Prerequesite:
1. Install Nextcloud (for exemple with [nextcloud-docker-dev](https://github.com/juliushaertl/nextcloud-docker-dev))
2. Choose Postgresql as database (important!)

Steps to reproduce using:
1. Connect as admin/admin
3. Create a vault
4. In another browser, connect as alice/alice
5. Create a vault
6. As admin, create a new credential and save
7. As admin, share the newly created credential and share with alice
8. validate and go back to the credentials list
9. Click on the new credential and select share
  → the sharing table is not displayed!

[issue-581.webm](https://github.com/nextcloud/passman/assets/371705/c0257668-8ac9-4813-b0b9-5cb5f00b4bd0)

## What is expected

[issue-581-fixed.webm](https://github.com/nextcloud/passman/assets/371705/26c59a42-e14c-4bc3-bdd0-caad83498d08)
