### PR TITLE
fix icon service for absolute base hrefs without server part

### DIFF
--- a/lib/Service/IconService.php
+++ b/lib/Service/IconService.php
@@ -214,9 +214,7 @@ class IconService {
 							if ($baseHrefType != self::URL_TYPE_ABSOLUTE) {
 								$this->icoUrl = $pageUrlInfo['scheme'] . '://' . $pageUrlInfo['host'] . $ico_href;
 								$this->findMethod .= ' with page href';
-							}
-							else
-							{
+							} else {
 								$baseUrlInfo = parse_url($base_href);
 								$this->icoUrl = $baseUrlInfo['scheme'] . '://' . $baseUrlInfo['host'] . $ico_href;
 								$this->findMethod .= ' with base href';

--- a/lib/Service/IconService.php
+++ b/lib/Service/IconService.php
@@ -212,11 +212,15 @@ class IconService {
 						if (isset($base_href)) {
 							$baseHrefType = self::urlType($base_href);
 							if ($baseHrefType != self::URL_TYPE_ABSOLUTE) {
-								throw new \Exception("Base href is not an absolute URL");
+								$this->icoUrl = $pageUrlInfo['scheme'] . '://' . $pageUrlInfo['host'] . $ico_href;
+								$this->findMethod .= ' with page href';
 							}
-							$baseUrlInfo = parse_url($base_href);
-							$this->icoUrl = $baseUrlInfo['scheme'] . '://' . $baseUrlInfo['host'] . $ico_href;
-							$this->findMethod .= ' with base href';
+							else
+							{
+								$baseUrlInfo = parse_url($base_href);
+								$this->icoUrl = $baseUrlInfo['scheme'] . '://' . $baseUrlInfo['host'] . $ico_href;
+								$this->findMethod .= ' with base href';
+							}
 						}
 						$this->icoType = self::getExtension($this->icoUrl);
 						break;


### PR DESCRIPTION
this fixes the scenario where an base href part is a absolute url but without a scheme and a domain part. In this case we should fall back to the scheme and domain part from the page itself.