### PR TITLE
Use square bracket syntax to modify array

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -70,10 +70,10 @@ class AdminController extends ApiController {
 		$results = array();
 		$searchResult = $this->userManager->search($term);
 		foreach ($searchResult as $user) {
-			array_push($results, array(
+			$results[] = [
 				"value" => $user->getUID(),
 				"label" => $user->getDisplayName() . ' (' . $user->getBackendClassName() . ')',
-			));
+			];
 		}
 		return new JSONResponse($results);
 	}
@@ -125,7 +125,7 @@ class AdminController extends ApiController {
 		foreach($requests as $request){
 			$r = $request->jsonSerialize();
 			$r['displayName'] = Utils::getNameByUid($request->getRequestedBy(), $this->userManager);
-			array_push($results, $r);
+			$results[] = $r;
 		}
 		return new JSONResponse($results);
 	}

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -176,7 +176,7 @@ class ShareController extends ApiController {
 					$this->notificationService->credentialSharedNotification(
 						$notification
 					);
-					array_push($processed_users, $target_user);
+					$processed_users[] = $target_user;
 
 					$this->activityService->add(
 						'item_shared', [$credential->getLabel(), $target_user],
@@ -277,13 +277,12 @@ class ShareController extends ApiController {
 		$user_vaults = $this->vaultService->getByUser($user_id);
 		$result = array();
 		foreach ($user_vaults as $vault) {
-			array_push($result,
-				array(
-					'vault_id' => $vault->getId(),
-					'guid' => $vault->getGuid(),
-					'public_sharing_key' => $vault->getPublicSharingKey(),
-					'user_id' => $user_id,
-				));
+			$result[] = [
+				'vault_id' => $vault->getId(),
+				'guid' => $vault->getGuid(),
+				'public_sharing_key' => $vault->getPublicSharingKey(),
+				'user_id' => $user_id,
+			];
 		}
 		return new JSONResponse($result);
 	}
@@ -332,7 +331,7 @@ class ShareController extends ApiController {
 				$result = $request->jsonSerialize();
 				$c = $this->credentialService->getCredentialLabelById($request->getItemId());
 				$result['credential_label'] = $c->getLabel();
-				array_push($results, $result);
+				$results[] = $result;
 			}
 			return new JSONResponse($results);
 		} catch (\Exception $ex) {

--- a/lib/Controller/VaultController.php
+++ b/lib/Controller/VaultController.php
@@ -71,7 +71,7 @@ class VaultController extends ApiController {
 				$credential = $this->credentialService->getRandomCredentialByVaultId($vault->getId(), $this->userId);
 				$secret_field = $protected_credential_fields[array_rand($protected_credential_fields)];
 				if (isset($credential)) {
-					array_push($result, array(
+					$result[] = [
 						'vault_id' => $vault->getId(),
 						'guid' => $vault->getGuid(),
 						'name' => $vault->getName(),
@@ -80,7 +80,7 @@ class VaultController extends ApiController {
 						'last_access' => $vault->getlastAccess(),
 						'challenge_password' => $credential->{$secret_field}(),
 						'delete_request_pending' => ($this->deleteVaultRequestService->getDeleteRequestForVault($vault->getGuid())) ? true : false
-					));
+					];
 				}
 			}
 		}

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -124,7 +124,7 @@ class FileService {
 		$files = $this->fileMapper->getFileGuidsFromUser($userId);
 		$results = array();
 		foreach ($files as $fileGuid) {
-			array_push($results, $fileGuid->getGuid());
+			$results[] = $fileGuid->getGuid();
 		}
 		return $results;
 	}

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -90,7 +90,7 @@ class ShareService {
 			$t->setPermissions($permissions);
 			$t->setCreated($created);
 			$t->setFromUserId($credential_owner);
-			array_push($requests, $this->shareRequest->createRequest($t));
+			$requests[] = $this->shareRequest->createRequest($t);
 		}
 		return $requests;
 	}


### PR DESCRIPTION
square bracket syntax is used instead of the array_push method, if we want to add one element to the array, it's better to use $array[] = because in that way there is no overhead of calling a function.