### PR TITLE
fix overwriting shared files field without permission

### DIFF
--- a/lib/Controller/CredentialController.php
+++ b/lib/Controller/CredentialController.php
@@ -155,6 +155,11 @@ class CredentialController extends ApiController {
 			if (!$this->settings->isEnabled('user_sharing_enabled')) {
 				return new DataResponse(['msg' => 'Not authorized'], Http::STATUS_UNAUTHORIZED);
 			}
+
+			if (!$acl->hasPermission(SharingACL::FILES)) {
+				// what ever the client transmitted, if it has no files permission, the previous files content will be preserved
+				$credential['files'] = $storedCredential->getFiles();
+			}
 		}
 
 


### PR DESCRIPTION
Fixes server bug:

When updating a credential shared with me (but without files permission) i don't get files from server. That's fine, but on update request (also without the files field) the server side files field will be cleared. That's bad. If the request has a files field, it would just overwrite the old one, without permission check.
