### PR TITLE
fix build error of version 2.4.10 with pinning uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "grunt-contrib-jshint": "^3.0.0",
     "grunt-contrib-nodeunit": "^5.0.0",
     "grunt-contrib-sass": "^2.0.0",
+    "uglify-js": "3.17.4",
     "grunt-contrib-uglify": "^5.0.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-html2js": "^0.8.0",


### PR DESCRIPTION
required version pinning of uglify-js to 3.17.4 as dependency of grunt-contrib-uglify to avoid / work around a critical build error (JS_Parse_Error [SyntaxError]: Calling delete on expression not allowed in strict mode) on the shipped js/vendor/forge.0.6.9.min.js file

fixes #823