### PR TITLE
add app-dark.svg

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -65,5 +65,6 @@ For an demo of this app visit [https://demo.passman.cc](https://demo.passman.cc)
 
     <settings>
         <admin>OCA\Passman\Settings\Admin</admin>
+        <admin-section>OCA\Passman\Settings\AdminSection</admin-section>
     </settings>
 </info>

--- a/img/app-dark.svg
+++ b/img/app-dark.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 68 68" enable-background="new 0 0 68 68" xml:space="preserve">
+<g>
+	<path d="M0,34c0,21.9,30,34,34,34c4,0,34-12.1,34-34V0H0V34z M45.4,50.3H22.6v-6.5h22.8V50.3z M21.6,16.2
+		c0,0,6.5,2.4,9.2,4.1c-0.6-2.6-1.2-10-1.2-10h8.6c0,0-0.6,7.8-1.2,10c1.2-0.6,9.4-4.1,9.4-4.1l2.7,8.3c0,0-7.5,1.8-10.1,1.9
+		c1.8,1.4,6.7,7.4,6.7,7.4l-7,5.3c0,0-3.8-6.3-5-8.9c-1.2,2.9-5,8.9-5,8.9l-7.2-5.3c0,0,5.7-6.3,7.1-7.4c-1.4-0.1-9.9-1.9-9.9-1.9
+		L21.6,16.2z"/>
+</g>
+</svg>

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -46,7 +46,7 @@ class SettingsController extends ApiController {
 	 * @return string the section ID, e.g. 'sharing'
 	 */
 	public function getSection() {
-		return 'additional';
+		return 'passman';
 	}
 
 	/**

--- a/lib/Notifier.php
+++ b/lib/Notifier.php
@@ -23,6 +23,7 @@
 
 namespace OCA\Passman;
 
+use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
@@ -31,6 +32,7 @@ class Notifier implements INotifier {
 
 	public function __construct(
 		protected IFactory $factory,
+		protected IURLGenerator $url,
 	) {
 	}
 
@@ -46,6 +48,11 @@ class Notifier implements INotifier {
 
 		// Read the language from the notification
 		$l = $this->factory->get('passman', $languageCode);
+
+		// Set the icon for the notification
+		$notification->setIcon(
+			$this->url->getAbsoluteURL($this->url->imagePath('passman', 'app-dark.svg'))
+		);
 
 		switch ($notification->getSubject()) {
 			// Deal with known subjects

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -95,7 +95,7 @@ class Admin implements ISettings {
 	 * @return string
 	 */
 	public function getSection(): string {
-		return 'additional';
+		return 'passman';
 	}
 
 	/**

--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Passman\Settings;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+class AdminSection implements IIconSection {
+	public function __construct(
+		private string $appName,
+		private IURLGenerator $url,
+		private IL10N $l,
+	) {
+	}
+
+	/**
+	 * returns the ID of the section. It is supposed to be a lower case string,
+	 * e.g. 'ldap'
+	 *
+	 * @returns string
+	 */
+	public function getID() {
+		return $this->appName;
+	}
+
+	/**
+	 * returns the translated name as it should be displayed, e.g. 'LDAP / AD
+	 * integration'. Use the L10N service to translate it.
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return $this->l->t('Passman');
+	}
+
+	/**
+	 * @return int whether the form should be rather on the top or bottom of
+	 *             the settings navigation. The sections are arranged in ascending order of
+	 *             the priority values. It is required to return a value between 0 and 99.
+	 *
+	 * E.g.: 70
+	 */
+	public function getPriority() {
+		return 70;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getIcon() {
+		return $this->url->imagePath($this->appName, 'app-dark.svg');
+	}
+}


### PR DESCRIPTION
## img: add app-dark.svg

Dark version of app.svg from 18615ebaed4c1e9b8d1a8c630768e1031c9f9cae

<img src="https://github.com/user-attachments/assets/a4c36484-45e7-4995-b156-29139e030f84" alt="Alt Text" width="64" height="64">


## OCA\Passman\Notifier: setIcon() 
Set the icon for the notification.

<img width="350" height="175" alt="0" src="https://github.com/user-attachments/assets/6942fdda-e76f-4f37-b583-2144dc278264" />

##  OCA\Passman\Settings: add AdminSection

Also rename the section from `additional` to `passman`.

<img width="770" height="373" alt="1" src="https://github.com/user-attachments/assets/c6893bd1-98dd-4745-b077-acbeebe68d6f" />


