### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/js/app/services/encryptservice.js
+++ b/js/app/services/encryptservice.js
@@ -34,10 +34,10 @@
 			// AngularJS will instantiate a singleton by calling "new" on this function
 			var encryption_config = {
 				adata: "",
-				iter: 1000,
+				iter: 100000,
 				ks: 256,
 				mode: 'ccm',
-				ts: 64
+				ts: 128
 			};
 
 			return {

--- a/js/app/services/settingsservice.js
+++ b/js/app/services/settingsservice.js
@@ -46,6 +46,9 @@
 			});
 
 			var cookie = localStorageService.get('settings');
+			if (cookie && cookie.defaultVaultPass !== undefined) {
+				delete cookie.defaultVaultPass;
+			}
 			settings = angular.merge(settings, cookie);
 			return {
 				getSettings: function () {
@@ -55,8 +58,11 @@
 					return settings[name];
 				},
 				setSetting: function (name, value) {
+					var storedSettings;
 					settings[name] = value;
-					localStorageService.set('settings', settings);
+					storedSettings = angular.copy(settings);
+					delete storedSettings.defaultVaultPass;
+					localStorageService.set('settings', storedSettings);
 				},
 				isEnabled: function (name) {
 					return settings[name] === 1 || settings[name] === '1';


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `js/app/services/encryptservice.js:L31`

The encryption configuration uses PBKDF iterations set to 1000 and an authentication tag size (`ts`) of 64 bits for SJCL CCM mode. For a password manager context, these settings are weak by modern standards and reduce resistance against brute-force and forgery attempts.

## Solution

Increase KDF work factor substantially (e.g., PBKDF2 >= 100k+ iterations or migrate to Argon2/scrypt if possible), and use a 128-bit authentication tag. Re-evaluate all crypto defaults against current best practices and threat model.

## Changes

- `js/app/services/encryptservice.js` (modified)
- `js/app/services/settingsservice.js` (modified)