### PR TITLE
fix: Cannot edit custom fields imported via generic CSV importer

### DIFF
--- a/js/app/controllers/edit_credential.js
+++ b/js/app/controllers/edit_credential.js
@@ -102,23 +102,40 @@
 				if ($scope.active_vault) {
 					$scope.$parent.selectedVault = true;
 				}
+				var supported_custom_field_types = ['text', 'password', 'file'];
+				var applyMissingCustomFieldTypes = function (credential) {
+					if (!credential || !angular.isArray(credential.custom_fields)) {
+						return credential;
+					}
+					for (var i = 0; i < credential.custom_fields.length; i++) {
+						var field = credential.custom_fields[i];
+						if (supported_custom_field_types.indexOf(field.field_type) !== -1) {
+							continue;
+						}
+						if (field.value !== null && angular.isObject(field.value) && field.value.filename !== undefined) {
+							field.field_type = 'file';
+						} else {
+							field.field_type = (field.secret === true || field.secret === 1 || field.secret === '1') ? 'password' : 'text';
+						}
+					}
+					return credential;
+				};
+
 				var storedCredential = SettingsService.getSetting('edit_credential');
 
 				if (!storedCredential) {
 					$scope.storedCredential = {}; // this line is required for reactive model binding to update the value from the async callback
 					CredentialService.getCredential($routeParams.credential_id).then(function (result) {
-						$scope.storedCredential = CredentialService.decryptCredential(angular.copy(result));
+						$scope.storedCredential = applyMissingCustomFieldTypes(CredentialService.decryptCredential(angular.copy(result)));
 						$scope.storedCredential.password_repeat = angular.copy($scope.storedCredential.password);
 						$scope.storedCredential.expire_time = $scope.storedCredential.expire_time * 1000;
-
 						//store password to check if it was changed if this credential has been compromised
 						$scope.oldPassword = $scope.storedCredential.password;
 					});
 				} else {
-					$scope.storedCredential = CredentialService.decryptCredential(angular.copy(storedCredential));
+					$scope.storedCredential = applyMissingCustomFieldTypes(CredentialService.decryptCredential(angular.copy(storedCredential)));
 					$scope.storedCredential.password_repeat = angular.copy($scope.storedCredential.password);
 					$scope.storedCredential.expire_time = $scope.storedCredential.expire_time * 1000;
-
 					//store password to check if it was changed if this credential has been compromised
 					$scope.oldPassword = $scope.storedCredential.password;
 				}

--- a/js/app/controllers/generic-csv-importer.js
+++ b/js/app/controllers/generic-csv-importer.js
@@ -150,7 +150,8 @@
 								_credential.custom_fields.push({
 									'label': key,
 									'value': row[k],
-									'secret': 0
+									'secret': 0,
+									'field_type': 'text'
 								});
 							} else if(field === 'custom_fields'){
 								if (row[k] !== undefined && (typeof row[k] === 'string' || row[k] instanceof String) && row[k].length > 1){

--- a/js/importers/importer-clipperz.js
+++ b/js/importers/importer-clipperz.js
@@ -61,7 +61,8 @@ var PassmanImporter = PassmanImporter || {};
 							{
 								'label': field_data.label,
 								'value': field_data.value,
-								'secret': (field_data.hidden === true)
+								'secret': (field_data.hidden === true),
+								'field_type': (field_data.hidden === true) ? 'password' : 'text'
 							}
 						)
 					}

--- a/js/importers/importer-enpass.js
+++ b/js/importers/importer-enpass.js
@@ -96,7 +96,8 @@ var PassmanImporter = PassmanImporter || {};
 							new_credential.custom_fields.push({
 								'label': key,
 								'value': enpass_credential[key],
-								'secret': isSecret
+								'secret': isSecret,
+								'field_type': (isSecret === 1) ? 'password' : 'text'
 							})
 						}
 					}

--- a/js/importers/importer-zohocsv.js
+++ b/js/importers/importer-zohocsv.js
@@ -59,7 +59,8 @@ var PassmanImporter = PassmanImporter || {};
 								{
 									'label': key,
 									'value': value,
-									'secret': false
+									'secret': false,
+									'field_type': 'text'
 								}
 							);
 						}


### PR DESCRIPTION
Fixes #365

## Root cause

Imported custom fields lack field_type, so the edit form cannot render them

## Changes

- Importers now store an explicit field_type ('text' or 'password' derived from the secret flag) for custom fields, and the edit-credential controller backfills a valid field_type for already-stored custom fields that miss it, so the edit form renders and allows editing their values.